### PR TITLE
Multiple tag types support

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -23,7 +23,7 @@ class Tags extends Field
 
         $class = get_class($model);
 
-        $class::saved(function($model) use ($tagNames) {
+        $class::saved(function ($model) use ($tagNames) {
             $model->syncTagsWithType($tagNames, $this->meta()['type'] ?? null);
         });
     }
@@ -31,6 +31,7 @@ class Tags extends Field
     public function resolveAttribute($resource, $attribute = null)
     {
         $attribute = $attribute ?? 'tags';
+        
         return $resource->{$attribute}->map(function (Tag $tag) {
             return ['id' => $tag->id, 'name' => $tag->name];
         });

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -30,7 +30,8 @@ class Tags extends Field
 
     public function resolveAttribute($resource, $attribute = null)
     {
-        return $resource->tags->map(function (Tag $tag) {
+        $attribute = $attribute ?? 'tags';
+        return $resource->{$attribute}->map(function (Tag $tag) {
             return ['id' => $tag->id, 'name' => $tag->name];
         });
     }

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -31,7 +31,7 @@ class Tags extends Field
     public function resolveAttribute($resource, $attribute = null)
     {
         $attribute = $attribute ?? 'tags';
-        
+
         return $resource->{$attribute}->map(function (Tag $tag) {
             return ['id' => $tag->id, 'name' => $tag->name];
         });


### PR DESCRIPTION
```
Tags::make('Genres', 'genres')->type('genre'),
Tags::make('Actors', 'actors')->type('actors'),
Tags::make('Tags', 'tags')->type('tags'),
```

Very quick fix, not sure that correct way to handle it.
But worked for me.