### PR TITLE
limitSuggestions in Tags.php

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -54,7 +54,7 @@ class Tags extends Field
 
     public function limitSuggestions(int $maxNumberOfSuggestions)
     {
-        return $this->withMeta(['suggestionLimit', $maxNumberOfSuggestions]);
+        return $this->withMeta(['suggestionLimit' => $maxNumberOfSuggestions]);
     }
 
     public function doNotLimitSuggestions()


### PR DESCRIPTION
Can't use method limitSuggestions because it does not override suggestionLimit.