### PR TITLE
Upgraded require version of laravel/spatie-tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.1.0",
         "laravel/nova": "*",
-        "spatie/laravel-tags": "^2.1"
+        "spatie/laravel-tags": "^2.2"
     },
     "require-dev": {
         "mockery/mockery": "^1.1",


### PR DESCRIPTION
In order to benefit from new commits on the spatie/laravel-tags dependency have upgraded to use ^2.2 instead of ^2.1