### PR TITLE
Sort the tags by name before returning

### DIFF
--- a/src/Http/Controllers/TagsFieldController.php
+++ b/src/Http/Controllers/TagsFieldController.php
@@ -29,7 +29,11 @@ class TagsFieldController extends Controller
             $query->limit($request['limit']);
         }
 
-        return $query->get()->map(function (Tag $tag) {
+        $sorted = $query->get()->sortBy(function (Tag $tag) {
+            return strtolower($tag->name);
+        })->values();
+
+        return $sorted->map(function (Tag $tag) {
             return $tag->name;
         });
     }


### PR DESCRIPTION
Thank you for the tags package and this Nova field!

I'm getting requests for the list of tags to be in alphabetical order. 

Currently, this is how they are showing up (in the order created):
<img width="819" alt="before" src="https://user-images.githubusercontent.com/350488/62502833-4618df00-b7a6-11e9-937e-39e66453f7e9.png">

This PR returns an alpha sorted list of tags:
<img width="801" alt="after" src="https://user-images.githubusercontent.com/350488/62502835-49ac6600-b7a6-11e9-8c29-ef481db072c8.png">


Thank you for your consideration!
