### PR TITLE
Consistent styling in Index Page

### DIFF
--- a/resources/js/components/Nova/IndexField.vue
+++ b/resources/js/components/Nova/IndexField.vue
@@ -1,5 +1,5 @@
 <template>
-    <p class="py-3 tags-index-field" v-html="typeof field.value === 'object' ? field.value.join(', ') : field.value"></p>
+    <div class="py-3 tags-index-field" v-html="typeof field.value === 'object' ? field.value.join(', ') : field.value"></div>
 </template>
 
 <script>


### PR DESCRIPTION
In the index page, the tags show up a little darker than the default styling.

#### Before
![image](https://user-images.githubusercontent.com/13273787/68692763-07ac7080-059c-11ea-85c2-10d64c2905ec.png)

#### After
![image](https://user-images.githubusercontent.com/13273787/68692867-404c4a00-059c-11ea-8adf-0c86b9b525cb.png)

