### PR TITLE
Fix withLinkToTagResource function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "laravel/nova": "^2.0",
+        "laravel/nova": "^2.9",
         "spatie/laravel-tags": "^2.3"
     },
     "require-dev": {

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -32,7 +32,9 @@ class Tags extends Field
 
         $uriKey = $tagResource::uriKey();
 
-        return $this->displayUsing(function ($tags) use ($class, $uriKey) {
+        return $this->displayUsing(function ($value, $resource, $attribute) use ($class, $uriKey) {
+            $tags = data_get($resource, $attribute);
+
             return $tags->map(function (Tag $tag) use ($class, $uriKey) {
                 $href = Nova::path().'/resources/'.$uriKey.'/'.$tag->id;
 

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -3,10 +3,10 @@
 namespace Spatie\TagsField;
 
 use Illuminate\Support\Arr;
-use Spatie\Tags\Tag;
-use Laravel\Nova\Nova;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Nova;
+use Spatie\Tags\Tag;
 
 class Tags extends Field
 {

--- a/tests/TagsFieldControllerTest.php
+++ b/tests/TagsFieldControllerTest.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\TagsField\Tests;
 
-use Spatie\Tags\Tag;
 use Laravel\Nova\Resource;
+use Spatie\Tags\Tag;
 use Spatie\TagsField\Tags;
 
 class TagsFieldControllerTest extends TestCase

--- a/tests/TagsFieldControllerTest.php
+++ b/tests/TagsFieldControllerTest.php
@@ -8,11 +8,19 @@ use Spatie\TagsField\Tags;
 
 class TagsFieldControllerTest extends TestCase
 {
+    /** @var TestModel */
+    protected $testModel;
+
     public function setUp(): void
     {
         parent::setUp();
 
         $this->createTags();
+
+        $this->testModel = TestModel::create([
+            'name' => 'model1',
+            'tags' => ['one'],
+        ]);
     }
 
     /** @test */
@@ -48,16 +56,18 @@ class TagsFieldControllerTest extends TestCase
     {
         $tags = Tag::all()->take(1);
 
+        $resource = $this->testModel->load('tags');
+
         $tagField = Tags::make('Tag');
         $this->assertNull($tagField->displayCallback);
 
         $tagField = Tags::make('Tag')->withLinkToTagResource(TagResource::class);
         $this->assertIsCallable($tagField->displayCallback);
-        $this->assertEquals('<a href="/nova/resources/tag-resources/1" class="no-underline dim text-primary font-bold">one</a>', call_user_func($tagField->displayCallback, $tags)->first());
+        $this->assertEquals('<a href="/nova/resources/tag-resources/1" class="no-underline dim text-primary font-bold">one</a>', call_user_func($tagField->displayCallback, $tags->toArray(), $resource, 'tags')->first());
 
         $tagField = Tags::make('Tag')->withLinkToTagResource(TagResource::class, 'custom-class');
         $this->assertIsCallable($tagField->displayCallback);
-        $this->assertEquals('<a href="/nova/resources/tag-resources/1" class="custom-class">one</a>', call_user_func($tagField->displayCallback, $tags)->first());
+        $this->assertEquals('<a href="/nova/resources/tag-resources/1" class="custom-class">one</a>', call_user_func($tagField->displayCallback, $tags->toArray(), $resource, 'tags')->first());
 
         $tagField = Tags::make('Tag')->displayUsing(function ($tags) {
             return $tags->map(function (Tag $tag) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Spatie\TagsField\Tests;
 
 use Dotenv\Dotenv;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Database\Schema\Blueprint;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\TagsField\TagsFieldServiceProvider;
 
@@ -15,7 +16,7 @@ abstract class TestCase extends Orchestra
 
         Route::middlewareGroup('nova', []);
 
-        $this->setUpDatabase();
+        $this->setUpDatabase($this->app);
     }
 
     protected function getPackageProviders($app)
@@ -52,12 +53,21 @@ abstract class TestCase extends Orchestra
         ]);
     }
 
-    protected function setUpDatabase()
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function setUpDatabase($app)
     {
         $this->artisan('migrate:fresh');
 
         include_once __DIR__.'/../vendor/spatie/laravel-tags/database/migrations/create_tag_tables.php.stub';
 
         (new \CreateTagTables())->up();
+
+        $app['db']->connection()->getSchemaBuilder()->create('test_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+        });
+
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,8 @@
 namespace Spatie\TagsField\Tests;
 
 use Dotenv\Dotenv;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\TagsField\TagsFieldServiceProvider;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -68,6 +68,5 @@ abstract class TestCase extends Orchestra
             $table->increments('id');
             $table->string('name')->nullable();
         });
-
     }
 }

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\TagsField\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Tags\HasTags;
+
+class TestModel extends Model
+{
+    use HasTags;
+
+    public $table = 'test_models';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}


### PR DESCRIPTION
Laravel nova has updated the usage of  `displayCallback` functions. 
( See https://github.com/laravel/nova/compare/v2.8.0...v2.9.0 #diff-afc68300b0a381cd43e118440d2feb50R216 )
