### PR TITLE
Encode unicode characters from inputs

### DIFF
--- a/resources/js/components/Tags/TagsInput.vue
+++ b/resources/js/components/Tags/TagsInput.vue
@@ -72,7 +72,7 @@ export default {
                 return;
             }
 
-            let queryString = `?filter[containing]=${this.input}&limit=${this.suggestionLimit}`;
+            let queryString = `?filter[containing]=${encodeURIComponent(this.input)}&limit=${this.suggestionLimit}`;
 
             if (this.type) {
                 queryString += `&filter[type]=${this.type}`;


### PR DESCRIPTION
First of all, thank you so much for this nova field!

Currently, when a user types a unicode character (i.e. '#') into the field, it will break the API call.
This PR will encode the inputs first before calling the API.

Thank you 😄 