### PR TITLE
Add wrap for overflowing suggestions

### DIFF
--- a/resources/sass/field.scss
+++ b/resources/sass/field.scss
@@ -48,6 +48,7 @@
     list-style: none;
     margin-top: 0.5rem;
     padding: 0;
+    flex-flow: row wrap;
 }
 
 .tags-input-suggestions li {


### PR DESCRIPTION
I've added a `flex-flow` style so that the overflowing suggestions will wrapped inside the input's div:

![image](https://user-images.githubusercontent.com/4866072/73545930-481eda80-4477-11ea-8708-ca399871b44b.png)

Thank you 😄 