### PR TITLE
add custom model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ public function fields(Request $request)
 
 The field will be rendered as a select form element. It will be populated by the names of the tags already saved.
 
+## Using a custom Tag Model
+
+The [underlying tags config file](https://github.com/spatie/laravel-tags/blob/master/config/tags.php) is used to specify the fully qualified class name of the tag model.
+
 ## Working with tags
 
 For more info on how to work with the saved tags, head over to [the docs of spatie/laravel-tags](https://docs.spatie.be/laravel-tags/).

--- a/src/Http/Controllers/TagsFieldController.php
+++ b/src/Http/Controllers/TagsFieldController.php
@@ -15,7 +15,7 @@ class TagsFieldController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Tag::query();
+        $query = config('tags.tag_model', Tag::class)::query();
 
         if ($request->has('filter.containing')) {
             $query->containing($request['filter']['containing']);


### PR DESCRIPTION
uses the model specified in the underlying spatie/laravel-tags package config file