### PR TITLE
Add support for spatie/laravel-tags 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.0|^7.3",
         "laravel/nova": "^3.0",
-        "spatie/laravel-tags": "^2.3|^3.0"
+        "spatie/laravel-tags": "^2.3|^3.0|^4.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",


### PR DESCRIPTION
No changes in laravel-tags API, so should be safe to add this new version