### PR TITLE
remove escape from tag

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -128,7 +128,7 @@ class Tags extends Field
         }
 
         return $tags->map(function (Tag $tag) {
-            return e($tag->name);
+            return $tag->name;
         })->values();
     }
 }


### PR DESCRIPTION
Hey @freekmurze, 
hello and thank you for this great package!

I've found an issue with the tag name being escaped before being displayed, resulting in a character like "&" being displayed as "\&amp;". This same issue has also been reported by @mrdj07 on #128.

Here an example ⬇️ 
<img width="287" alt="image" src="https://user-images.githubusercontent.com/2118799/140654763-1342d2b2-aa8d-4254-80b8-3711c6a29086.png">

This PR will fix the issue by removing the escape function, thus letting the tag name be displayed directly without any modification.

I've tested on local and it shouldn't break anything.