### PR TITLE
Don't call containing scope when containing input is null

### DIFF
--- a/src/Http/Controllers/TagsFieldController.php
+++ b/src/Http/Controllers/TagsFieldController.php
@@ -17,7 +17,7 @@ class TagsFieldController extends Controller
     {
         $query = resolve(config('tags.tag_model', Tag::class))->query();
 
-        if ($request->has('filter.containing')) {
+        if ($request->input('filter.containing') !== null) {
             $query->containing($request['filter']['containing']);
         }
 


### PR DESCRIPTION
When a user types a space of more a request is sent to the backend and because the check is only if the field exists on the request `if ($request->has('filter.containing')) {` the package is calling the scope, but t accepts only strings and not null and this results in an error. The value is null because it is passed thru laravel's middlewares that convert empty strings to null.
This PR fixes this issue but this might not be the best way to fix it for the project.