### PR TITLE
Dark mode support

### DIFF
--- a/resources/js/components/Tags/MultiTagsInput.vue
+++ b/resources/js/components/Tags/MultiTagsInput.vue
@@ -36,7 +36,7 @@
                 <input
                     v-if="canAddTag"
                     ref="input"
-                    class="tags-input-text"
+                    class="tags-input-text dark:bg-gray-900"
                     :placeholder="placeholder ? placeholder : __('Add tag...')"
                     v-bind="inputProps"
                     v-on="inputEvents"


### PR DESCRIPTION
Dark mode support for input.

Before:
<img width="813" alt="Снимок экрана 2022-04-07 в 10 58 12" src="https://user-images.githubusercontent.com/4685504/162149907-8acd53d7-0ced-44f1-9998-5fac8ca5a811.png">

After:
<img width="796" alt="Снимок экрана 2022-04-07 в 10 58 20" src="https://user-images.githubusercontent.com/4685504/162149934-9e31240a-ead9-47c0-baa1-eaca63b0cc4d.png">

