### PR TITLE
Ability to set the default value for the tag field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ phpunit.xml
 mix-manifest.json
 .php_cs.cache
 .php-cs-fixer.cache
+.idea


### PR DESCRIPTION
Because of the way the value is defined, Nova does not call the `resolveDefaultValue` method, which can be used to define default values the field.

I have added functionality to use the `default` method.

To use this functionality, you must pass an array or collection of Tag models as a default value.