### PR TITLE
stop passing null values to explode()

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -109,8 +109,7 @@ class Tags extends Field
     protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
         $requestValue = $request[$requestAttribute];
-        $tagNames = explode('-----', $requestValue);
-        $tagNames = array_filter($tagNames);
+        $tagNames = is_null($requestValue) ? [] : array_filter(explode('-----', $requestValue));
 
         $class = get_class($model);
 


### PR DESCRIPTION
This PR is related to this discussion: https://github.com/spatie/nova-tags-field/discussions/168

I have also noticed a lot of these logs in our laravel/nova admin panel:

```
explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/brain/vendor/spatie/nova-tags-field/src/Tags.php on line 112
```

The update that I have made simply returns `[]` when it detects that the value we're dealing with is `null`.