### PR TITLE
Fixed Dropdown error in Action fields due to null value

### DIFF
--- a/resources/js/components/Nova/FormField.vue
+++ b/resources/js/components/Nova/FormField.vue
@@ -31,7 +31,7 @@ export default {
 
     data() {
         return {
-            tags: this.field.value,
+            tags: this.field.value || [],
         };
     },
 


### PR DESCRIPTION
tags must be an array, if this.field.value is null, it should be initialized as an empty array. This fixes this issue:

https://github.com/spatie/nova-tags-field/discussions/175