### PR TITLE
Revert asset loading from Nova::mix() to Nova::script()

### DIFF
--- a/src/TagsFieldServiceProvider.php
+++ b/src/TagsFieldServiceProvider.php
@@ -12,8 +12,7 @@ class TagsFieldServiceProvider extends ServiceProvider
     public function boot()
     {
         Nova::serving(function (ServingNova $event) {
-            Nova::mix('nova-tags-field', __DIR__.'/../dist/mix-manifest.json');
-            //Nova::style('nova-tags-field', __DIR__.'/../dist/css/field.css');
+            Nova::script('nova-tags-field', __DIR__.'/../dist/js/field.js');
         });
 
         $this->app->booted(function () {


### PR DESCRIPTION
## Summary

- Reverts the asset loading change introduced in #187 (v5.0.1) that switched from `Nova::script()` to `Nova::mix()`
- The `Nova::mix()` call expects a `mix-manifest.json` in the dist directory, which doesn't exist, causing the field to not render at all in index, detail, and form views
- Reverting to `Nova::script()` which directly loads the compiled JS file that does exist in `dist/js/field.js`

Fixes #184

@crynobone does this work for you? The `Nova::mix()` approach would need a proper build step that generates `mix-manifest.json` in the dist directory before it can work.